### PR TITLE
OpenSSL arguments must not be quoted

### DIFF
--- a/hpkp-gen
+++ b/hpkp-gen
@@ -161,7 +161,7 @@ do
   esac
 
   # Create the public key
-  openssl "${OPENSSL_ARGS}" -in "${FILE}" | openssl asn1parse -inform pem -noout -out "${TMPFILE}"
+  openssl ${OPENSSL_ARGS} -in "${FILE}" | openssl asn1parse -inform pem -noout -out "${TMPFILE}"
 
   # Create the hash from the public key.
   PHASH=$(openssl dgst -sha256 -binary "${TMPFILE}" | openssl enc -base64)


### PR DESCRIPTION
They have to be passed independently and not as a whole (which is what happen with double quoting).
